### PR TITLE
Better handle concurrent reads from the port

### DIFF
--- a/amplifier_test.go
+++ b/amplifier_test.go
@@ -15,3 +15,5 @@ func (t *testAmp) execute(cmd string) error {
 func (t *testAmp) read() (string, error) {
 	return t.data, t.readErr
 }
+func (t *testAmp) lock()   {}
+func (t *testAmp) unlock() {}

--- a/state.go
+++ b/state.go
@@ -10,7 +10,7 @@ var (
 	// ErrInvalidCommandCode is returned if an invalid command code is detected
 	ErrInvalidCommandCode = errors.New("invalid command code")
 	// ErrInvalidInput is detected if the command string format doesn't match as expected
-	ErrInvalidInput       = errors.New("invalid command string")
+	ErrInvalidInput = errors.New("invalid command string")
 )
 
 // State contains the current state of a given zone, as retrieved from the controller.

--- a/zone.go
+++ b/zone.go
@@ -40,6 +40,10 @@ func (z *Zone) ID() string {
 func (z *Zone) Refresh() error {
 	cmd := fmt.Sprintf("%s%s\r", queryRequestPrefix, z.ID())
 
+	// Synchronize writes to the amp to avoid reading back interleaved output
+	z.a.lock()
+	defer z.a.unlock()
+
 	err := z.a.execute(cmd)
 	if err != nil {
 		return err
@@ -169,6 +173,10 @@ func (z *Zone) SetSourceChannel(channelID int) error {
 
 // set applies the request action to the zone.
 func (z *Zone) set(ac actionCode, actionValue int) error {
+	// Synchronize writes to the amp to avoid reading back interleaved output
+	z.a.lock()
+	defer z.a.unlock()
+
 	cmd := fmt.Sprintf("%s%s%s%02d\r", controlRequestPrefix, z.ID(), ac, actionValue)
 	return z.a.execute(cmd)
 }


### PR DESCRIPTION
* concurrent reads are protected at the zone layer now
* provide a Reset method to clean up if concurrency issues arise